### PR TITLE
Julia version using BLAS gemm

### DIFF
--- a/ClassifyDigits.jl
+++ b/ClassifyDigits.jl
@@ -1,8 +1,5 @@
 import Base: sumabs2, LinAlg.BLAS.gemm!
  
-trainingfile = download("https://github.com/c4fsharp/Dojo-Digits-Recognizer/blob/1eb4297a49dbd82a952c1523f5413519b8f1d62a/Dojo/trainingsample.csv?raw=true")
-validationfile = download("https://github.com/c4fsharp/Dojo-Digits-Recognizer/blob/1eb4297a49dbd82a952c1523f5413519b8f1d62a/Dojo/validationsample.csv?raw=true")
- 
 function knn(tfile, vfile)
     (tdata, theader) = readcsv(tfile, Uint8, header = true) # if this errors, replace header with has_header
     (vdata, vheader) = readcsv(vfile, Uint8, header = true)
@@ -35,10 +32,7 @@ function knn(tfile, vfile)
 end
  
 # don't time the first run - otherwise should include compile time for static languages
-knn(trainingfile, validationfile)
-@time knn(trainingfile, validationfile)
-@time knn(trainingfile, validationfile)
-@time knn(trainingfile, validationfile)
- 
-rm(trainingfile)
-rm(validationfile)
+knn("trainingsample.csv", "validationsample.csv")
+@time knn("trainingsample.csv", "validationsample.csv")
+@time knn("trainingsample.csv", "validationsample.csv")
+@time knn("trainingsample.csv", "validationsample.csv")


### PR DESCRIPTION
This runs in 1.8 seconds on a Xeon E5410 running RHEL5. It likely requires a recent Julia 0.3.0 prerelease built within the last month or so, I'm not sure exactly what minimum version is required.

Compare to a roughly 4x slower Julia version that does not use BLAS here
https://gist.github.com/anonymous/c7501c8bbf4ac7ba8a20

Unfortunately I can't get a new enough OCaml or F# on this distribution for a direct comparison, at least not easily. Rust doesn't have binaries for RHEL5 to compare to this version https://news.ycombinator.com/item?id=7872398, and [the C++ example from the comments](http://pastebin.com/5pMka6ZJ) fails to compile even with GCC 4.8.0 due to the old version of Boost in `/usr/include/boost`. I should get a newer machine and/or better distribution.
